### PR TITLE
Add Python HTTP GET request to GitHub API

### DIFF
--- a/http_github_get_request.py
+++ b/http_github_get_request.py
@@ -1,0 +1,14 @@
+import requests
+
+# send http GET request and receive response
+resp = requests.get(
+    url="https://api.github.com/repos/Brillianttyagi/Python-script")
+
+# unmarshal JSON
+json_resp = resp.json()
+
+name = json_resp["full_name"]
+stars = json_resp["stargazers_count"]
+
+# printing the number of stars
+print("GitHub repository '%s' has %s stars." % (name, stars))


### PR DESCRIPTION
#1 Add a script for a basic HTTP GET request to the GitHub API to print the number of stars for this repo.